### PR TITLE
fix: service monitoring configuration

### DIFF
--- a/charts/passbolt-operator/Chart.yaml
+++ b/charts/passbolt-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/passbolt-operator/templates/deployment.yaml
+++ b/charts/passbolt-operator/templates/deployment.yaml
@@ -35,7 +35,8 @@ spec:
             capabilities:
               drop:
                 - "ALL"
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+          image: {{ .Values.monitoring.rbacProxy.image.repository }}:{{ .Values.monitoring.rbacProxy.image.tag }}
+          imagePullPolicy: {{ .Values.monitoring.rbacProxy.image.pullPolicy }}
           args:
           - "--secure-listen-address=0.0.0.0:8443"
           - "--upstream=http://127.0.0.1:8080/"

--- a/charts/passbolt-operator/templates/deployment.yaml
+++ b/charts/passbolt-operator/templates/deployment.yaml
@@ -28,7 +28,32 @@ spec:
       serviceAccountName: {{ include "passbolt-operator.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
       containers:
-        - name: {{ .Chart.Name }}
+        {{- if .Values.monitoring.enabled }}
+        - name: kube-rbac-proxy
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+          args:
+          - "--secure-listen-address=0.0.0.0:8443"
+          - "--upstream=http://127.0.0.1:8080/"
+          - "--logtostderr=true"
+          - "--v=0"
+          ports:
+          - containerPort: 8443
+            protocol: TCP
+            name: metrics
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 5m
+              memory: 64Mi
+        {{- end }}
+        - name: manager
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -39,7 +64,11 @@ spec:
           command:
           - /controller
           args:
-          - --leader-elect
+          - "--health-probe-bind-address=:8081"
+          {{- if .Values.monitoring.enabled }}
+          - "--metrics-bind-address=127.0.0.1:8080"
+          {{- end }}
+          - "--leader-elect"
           env:
           {{- if .Values.secret.name }}
             - name: PASSBOLT_URL
@@ -74,10 +103,6 @@ spec:
                   name: {{ include "passbolt-operator.secret.name" . }}
                   key: gpg_key
           {{- end }}
-          ports:
-            - name: http
-              containerPort: 8081
-              protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/passbolt-operator/templates/deployment.yaml
+++ b/charts/passbolt-operator/templates/deployment.yaml
@@ -46,12 +46,7 @@ spec:
             protocol: TCP
             name: metrics
           resources:
-            limits:
-              cpu: 500m
-              memory: 128Mi
-            requests:
-              cpu: 5m
-              memory: 64Mi
+            {{- toYaml .Values.monitoring.rbacProxy.resources | nindent 12 }}
         {{- end }}
         - name: manager
           securityContext:

--- a/charts/passbolt-operator/templates/service.yaml
+++ b/charts/passbolt-operator/templates/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.monitoring.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "passbolt-operator.fullname" . }}-metrics
+  labels:
+    {{- include "passbolt-operator.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8443
+    targetPort: metrics
+    protocol: TCP
+    name: metrics
+  selector:
+    {{- include "passbolt-operator.selectorLabels" . | nindent 8 }}
+{{- end }}

--- a/charts/passbolt-operator/templates/service_monitor.yaml
+++ b/charts/passbolt-operator/templates/service_monitor.yaml
@@ -1,11 +1,11 @@
-{{- if and .Values.monitoring.enabled .Values.monitoring.ServiceMonitor.enabled }}
+{{- if and .Values.monitoring.enabled .Values.monitoring.serviceMonitor.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "passbolt-operator.fullname" . }}
-  {{- if .Values.monitoring.ServiceMonitor.namespace }}
-  namespace: {{ .Values.monitoring.ServiceMonitor.namespace }}
+  {{- if .Values.monitoring.serviceMonitor.namespace }}
+  namespace: {{ .Values.monitoring.serviceMonitor.namespace }}
   {{- end }}
   labels:
     {{- include "passbolt-operator.labels" . | nindent 4 }}

--- a/charts/passbolt-operator/templates/service_monitor.yaml
+++ b/charts/passbolt-operator/templates/service_monitor.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   endpoints:
     - path: /metrics
-      port: https
+      port: metrics
       scheme: https
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:

--- a/charts/passbolt-operator/values.yaml
+++ b/charts/passbolt-operator/values.yaml
@@ -83,6 +83,16 @@ affinity: {}
 monitoring:
   # -- Enable Prometheus Operator Monitoring
   enabled: false
+  # -- RBAC Proxy configuration
+  rbacProxy:
+    # -- RBAC Proxy resource configuration
+    resources: {}
+      # limits:
+      #   cpu: 500m
+      #   memory: 128Mi
+      # requests:
+      #   cpu: 5m
+      #   memory: 64Mi
   # -- ServiceMonitor configuration
   serviceMonitor:
     # -- Enable ServiceMonitor

--- a/charts/passbolt-operator/values.yaml
+++ b/charts/passbolt-operator/values.yaml
@@ -85,6 +85,14 @@ monitoring:
   enabled: false
   # -- RBAC Proxy configuration
   rbacProxy:
+    # -- Image to use for the RBAC Proxy
+    image:
+      # -- Image repository
+      repository: gcr.io/kubebuilder/kube-rbac-proxy
+      # -- Image pull policy
+      pullPolicy: IfNotPresent
+      # -- Tag overrides the image tag whose default is the chart appVersion.
+      tag: "v0.13.0"
     # -- RBAC Proxy resource configuration
     resources: {}
       # limits:


### PR DESCRIPTION
# Description

This fix adds the missing service monitor configuration to the Helm chart. Before this fix was introduced, it was not possible to retrieve the metrics from the operator.

## How Has This Been Tested?

- [x] locally using

```bash
helm upgrade --install \
    passbolt-operator ./charts/passbolt-operator \
    --set "monitoring.enabled=true" \
    --set "monitoring.serviceMonitor.enabled=true"
```

**Test Configuration**:

- Kubernetes version: `v1.25.3`
- Kubectl version: `v1.26.1`
- Node operation system: `Ubuntu 22.04`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
