### PR TITLE
feat: added passbolt-secret Helm chart definition

### DIFF
--- a/charts/passbolt-secret/.helmignore
+++ b/charts/passbolt-secret/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/passbolt-secret/Chart.yaml
+++ b/charts/passbolt-secret/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: passbolt-secret
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/passbolt-secret/templates/NOTES.txt
+++ b/charts/passbolt-secret/templates/NOTES.txt
@@ -1,0 +1,2 @@
+1. The secret has been successfully created.
+2. You can now reference the Kubernetes secret in your application by it's name: "{{ include "passbolt-secret.fullname" . }}"

--- a/charts/passbolt-secret/templates/_helpers.tpl
+++ b/charts/passbolt-secret/templates/_helpers.tpl
@@ -1,0 +1,42 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "passbolt-secret.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "passbolt-secret.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "passbolt-secret.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "passbolt-secret.labels" -}}
+helm.sh/chart: {{ include "passbolt-secret.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/passbolt-secret/templates/passbolt_secret.yaml
+++ b/charts/passbolt-secret/templates/passbolt_secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: passbolt.tagesspiegel.de/v1alpha1
+kind: PassboltSecret
+metadata:
+  name: {{ include "passbolt-secret.fullname" . }}
+  labels:
+    {{- include "passbolt-secret.labels" . | nindent 4 }}
+spec:
+  leaveOnDelete: false
+  secrets:
+    {{- toYaml .Values.secrets | nindent 4 }}

--- a/charts/passbolt-secret/values.yaml
+++ b/charts/passbolt-secret/values.yaml
@@ -11,13 +11,13 @@ fullnameOverride: ""
 # passbolt secret is deleted.
 leaveOnDelete: false
 
-secrets:
-  - # kubernetesSecretKey is the name of the secret key to be created in Kubernetes secrets resource
-    kubernetesSecretKey: ""
-    # passboltSecret represents the passbolt secret to be referenced in the passbolt instance
-    passboltSecret:
-      # name is the name of the passbolt secret to be referenced
-      name: ""
-      # field is the name of the passbolt secret field to be referenced
-      # valid values are: "username", "password", "uri"
-      field: ""
+secrets: []
+  # - # kubernetesSecretKey is the name of the secret key to be created in Kubernetes secrets resource
+  #   kubernetesSecretKey: ""
+  #   # passboltSecret represents the passbolt secret to be referenced in the passbolt instance
+  #   passboltSecret:
+  #     # name is the name of the passbolt secret to be referenced
+  #     name: ""
+  #     # field is the name of the passbolt secret field to be referenced
+  #     # valid values are: "username", "password", "uri"
+  #     field: ""

--- a/charts/passbolt-secret/values.yaml
+++ b/charts/passbolt-secret/values.yaml
@@ -1,0 +1,23 @@
+# Default values for passbolt-secret.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+nameOverride: ""
+fullnameOverride: ""
+
+# leaveOnDelete is a flag to indicate if the Kubernetes secret should be deleted when the
+# corresponding passbolt secret is deleted. If set to true, the secret will be deleted when
+# the passbolt secret is deleted. If set to false, the secret will not be deleted when the
+# passbolt secret is deleted.
+leaveOnDelete: false
+
+secrets:
+  - # kubernetesSecretKey is the name of the secret key to be created in Kubernetes secrets resource
+    kubernetesSecretKey: ""
+    # passboltSecret represents the passbolt secret to be referenced in the passbolt instance
+    passboltSecret:
+      # name is the name of the passbolt secret to be referenced
+      name: ""
+      # field is the name of the passbolt secret field to be referenced
+      # valid values are: "username", "password", "uri"
+      field: ""


### PR DESCRIPTION
# Description

This PR adds the passbolt-secret resource definition as Helm chart to the repository. This allows us to reference the secret as dependency and define the required key/secret references.

## How Has This Been Tested?

- locally using `helm upgrade --install my-secret ./charts/passbolt-secret` 

**Test Configuration**:

- Kubernetes version: `v1.25.3`
- Kubectl version: `v1.26.1`
- Node operation system: `Ubuntu 22.04`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
