### PR TITLE
fix: typo in ServiceMonitor value reference

### DIFF
--- a/charts/passbolt-operator/templates/service_monitor.yaml
+++ b/charts/passbolt-operator/templates/service_monitor.yaml
@@ -1,11 +1,11 @@
-{{- if and .Values.monitoring.enabled .Values.monitoring.ServiceMonitor.enabled }}
+{{- if and .Values.monitoring.enabled .Values.monitoring.serviceMonitor.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "passbolt-operator.fullname" . }}
-  {{- if .Values.monitoring.ServiceMonitor.namespace }}
-  namespace: {{ .Values.monitoring.ServiceMonitor.namespace }}
+  {{- if .Values.monitoring.serviceMonitor.namespace }}
+  namespace: {{ .Values.monitoring.serviceMonitor.namespace }}
   {{- end }}
   labels:
     {{- include "passbolt-operator.labels" . | nindent 4 }}


### PR DESCRIPTION
# Description

This PR fixes the reference to the ServiceMonitor value reference.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
