### PR TITLE
fix: passbolt operator crd deployment

### DIFF
--- a/charts/passbolt-operator/Chart.yaml
+++ b/charts/passbolt-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.2
+version: 1.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/passbolt-operator/README.md
+++ b/charts/passbolt-operator/README.md
@@ -1,6 +1,6 @@
 # passbolt-operator
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
+![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
 
 A Helm chart to deploy the Passbolt Operator. The Passbolt Operator is a Kubernetes Operator to manage Passbolt Secrets in Kubernetes (Passbolt --> Kubernetes secret).
 

--- a/charts/passbolt-operator/templates/crds/crd-passboltsecrets.yaml
+++ b/charts/passbolt-operator/templates/crds/crd-passboltsecrets.yaml
@@ -18,6 +18,8 @@ spec:
       - v1alpha1
       - v1alpha2
       - v1alpha3
+      - v1beta1
+      - v1
   group: passbolt.tagesspiegel.de
   names:
     kind: PassboltSecret


### PR DESCRIPTION
# Description

Added missing v1beta1 and v1 version. For some stupid reason, Kubernetes requires a stable v1 or v1beta1 version for the CRD, event if the CRD has not such version.

Error:

```
CustomResourceDefinition.apiextensions.k8s.io "passboltsecrets.passbolt.tagesspiegel.de" is invalid: spec.conversion.conversionReviewVersions: Invalid value: []string{"v1alpha1", 
"v1alpha2", "v1alpha3"}: must include at least one of v1, v1beta1
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
