### PR TITLE
fix: remove plainTextFields if empty

### DIFF
--- a/charts/passbolt-secret/Chart.yaml
+++ b/charts/passbolt-secret/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.1
+version: 2.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/passbolt-secret/templates/passbolt_secret.yaml
+++ b/charts/passbolt-secret/templates/passbolt_secret.yaml
@@ -12,6 +12,8 @@ spec:
   {{- else }}
   passboltSecrets:
     {{- toYaml .Values.passboltSecrets | nindent 4 }}
+  {{- if .Values.plainTextSecrets }}
   plainTextFields:
     {{- toYaml .Values.plainTextSecrets | nindent 4 }}
+  {{- end }}
   {{- end }}


### PR DESCRIPTION
# Description

In the past, we set the plainTextFields property even if the field was empty. Since the passbolt operator automatically deletes some empty fields, ArgoCD always detected a change and kept resynchronizing the secrets (sync loop). To prevent this sync loop, we decided not to set the field if it is empty.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
