### PR TITLE
feat: update passbolt operator to latest version

### DIFF
--- a/charts/passbolt-operator/Chart.yaml
+++ b/charts/passbolt-operator/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0
+version: 2.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.0.0"
+appVersion: "v2.1.0"
 
 home: https://github.com/urbanmedia/passbolt-operator
 sources:

--- a/charts/passbolt-operator/README.md
+++ b/charts/passbolt-operator/README.md
@@ -1,6 +1,6 @@
 # passbolt-operator
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.0.0](https://img.shields.io/badge/AppVersion-v2.0.0-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.1.0](https://img.shields.io/badge/AppVersion-v2.1.0-informational?style=flat-square)
 
 A Helm chart to deploy the Passbolt Operator. The Passbolt Operator is a Kubernetes Operator to manage Passbolt Secrets in Kubernetes (Passbolt --> Kubernetes secret).
 

--- a/charts/passbolt-operator/templates/crds/crd-passboltsecrets.yaml
+++ b/charts/passbolt-operator/templates/crds/crd-passboltsecrets.yaml
@@ -34,6 +34,136 @@ spec:
     - jsonPath: .status.lastSync
       name: Last Sync
       type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: PassboltSecret is the Schema for the passboltsecrets API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PassboltSecretSpec defines the desired state of PassboltSecret
+            properties:
+              leaveOnDelete:
+                default: true
+                description: LeaveOnDelete defines if the secret should be deleted
+                  from Kubernetes when the PassboltSecret is deleted.
+                type: boolean
+              passboltSecretID:
+                description: PassboltSecretID is the ID of the passbolt secret to
+                  be used as a docker config secret.
+                type: string
+              passboltSecrets:
+                additionalProperties:
+                  properties:
+                    field:
+                      description: Field is the field in the passbolt secret to be
+                        read.
+                      enum:
+                      - username
+                      - password
+                      - uri
+                      type: string
+                    id:
+                      description: Name of the secret in passbolt
+                      type: string
+                    value:
+                      description: 'Value is the plain text value of the secret. This
+                        field allows to set a static value or using go templating
+                        to generate the value. Valid template variables are: - Password
+                        - Username - URI'
+                      type: string
+                  required:
+                  - id
+                  type: object
+                description: PassboltSecrets is a map of string (key in K8s secret)
+                  and struct that contains the reference to the secret in passbolt.
+                type: object
+              plainTextFields:
+                additionalProperties:
+                  type: string
+                description: PlainTextFields is a map of string (key in K8s secret)
+                  and string (value in K8s secret).
+                type: object
+              secretType:
+                default: Opaque
+                description: SecretType is the type of the secret. Defaults to Opaque.
+                  If set to kubernetes.io/dockerconfigjson, the secret will be created
+                  as a docker config secret. We also expect the PassboltSecretName
+                  to be set in this case.
+                enum:
+                - Opaque
+                - kubernetes.io/dockerconfigjson
+                type: string
+            type: object
+          status:
+            description: PassboltSecretStatus defines the observed state of PassboltSecret
+            properties:
+              lastSync:
+                description: LastSync is the last time the secret was synced from
+                  passbolt.
+                format: date-time
+                type: string
+              syncErrors:
+                description: SyncErrors is a list of errors that occurred during the
+                  last sync.
+                items:
+                  properties:
+                    message:
+                      description: Message is the error message.
+                      type: string
+                    passboltSecretID:
+                      description: PassboltSecretID is the name of the secret that
+                        failed to sync.
+                      type: string
+                    secretKey:
+                      description: SecretKey is the key of the secret that failed
+                        to sync.
+                      type: string
+                    time:
+                      description: Time is the time the error occurred.
+                      format: date-time
+                      type: string
+                  required:
+                  - message
+                  - passboltSecretID
+                  - secretKey
+                  - time
+                  type: object
+                type: array
+              syncStatus:
+                default: Unknown
+                description: SyncStatus is the status of the last sync.
+                enum:
+                - Success
+                - Error
+                - Unknown
+                type: string
+            required:
+            - syncStatus
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.syncStatus
+      name: Sync Status
+      type: string
+    - jsonPath: .status.lastSync
+      name: Last Sync
+      type: string
     name: v1alpha2
     schema:
       openAPIV3Schema:

--- a/charts/passbolt-secret/Chart.yaml
+++ b/charts/passbolt-secret/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.2
+version: 2.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.0.0"
+appVersion: "v2.1.0"
 
 home: https://github.com/urbanmedia/passbolt-operator
 

--- a/charts/passbolt-secret/README.md
+++ b/charts/passbolt-secret/README.md
@@ -1,6 +1,6 @@
 # passbolt-secret
 
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.0.0](https://img.shields.io/badge/AppVersion-v2.0.0-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.1.0](https://img.shields.io/badge/AppVersion-v2.1.0-informational?style=flat-square)
 
 A Helm chart for setting up a passbolt secret in Kubernetes
 

--- a/charts/passbolt-secret/templates/passbolt_secret.yaml
+++ b/charts/passbolt-secret/templates/passbolt_secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: passbolt.tagesspiegel.de/v1alpha3
+apiVersion: passbolt.tagesspiegel.de/v1
 kind: PassboltSecret
 metadata:
   name: {{ include "passbolt-secret.fullname" . }}


### PR DESCRIPTION
# Description

The latest available version of the passbolt operator and the stable api version v1 have been added to the passbolt operator Helm chart. Also, the Passbolt Secrets helm chart has been modified to create secrets based on the latest stable api version (v1).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
